### PR TITLE
Update Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>tools.profiler</groupId>
@@ -28,20 +28,19 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.2</version>
+            <version>2.18.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.2</version>
+            <version>5.11.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <!-- use 2.9.1 for Java 7 projects -->
-            <version>3.11.1</version>
+            <version>3.26.3</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Dependencies should be up-to-date, as far as possible. Therefore, I updated everything that is updatable withour major version updates: Update commons-io to 2.17.0, jackson-databind to 2.18.0, junit-jupiter-engine to 5.11.2 and assertj-core to 3.26.3.

Checking whether an update to async-profiler 3.0 is possible would also make sense.