### PR TITLE
Ignore target/ since it shouldn't be versioned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Compiled class file
 *.class
+target/
 
 # Log file
 *.log


### PR DESCRIPTION
target/ in the main maven folder should never be versioned (.class files usually shouldn't be created - but in case `src/test/resources` contains maven projects, that themselves create target folders, it might make sense to leave it as it is.